### PR TITLE
Fix build error on windows 10.

### DIFF
--- a/driver/kernel/windows/windows_gasket_ioctl.inc
+++ b/driver/kernel/windows/windows_gasket_ioctl.inc
@@ -96,6 +96,7 @@ struct gasket_address_map_ioctl {
 #ifndef __KERNEL__
 
 #include "port/logging.h"
+#include "port/stringprintf.h"
 
 namespace platforms {
 namespace darwinn {


### PR DESCRIPTION
Resolves #6

### This pull request changes
Fix build error on windows 10. (error C3861: 'StringPrintf')
Supersedes #7