### PR TITLE
Add missing cstddef header for size_t on GCC-11.

### DIFF
--- a/api/allocated_buffer.h
+++ b/api/allocated_buffer.h
@@ -16,6 +16,7 @@
 #define DARWINN_API_ALLOCATED_BUFFER_H_
 
 #include <functional>
+#include <cstddef>
 
 namespace platforms {
 namespace darwinn {


### PR DESCRIPTION
This was probably getting implicitly included through <functional> on
older compilers.