### PR TITLE
include cstddef

### DIFF
--- a/api/allocated_buffer.h
+++ b/api/allocated_buffer.h
@@ -15,6 +15,7 @@
 #ifndef DARWINN_API_ALLOCATED_BUFFER_H_
 #define DARWINN_API_ALLOCATED_BUFFER_H_
 
+#include <cstddef>
 #include <functional>
 
 namespace platforms {

--- a/driver/hardware_structures.h
+++ b/driver/hardware_structures.h
@@ -19,6 +19,7 @@
 
 #include <stddef.h>
 #include <algorithm>
+#include <cstdint>
 
 #include "port/integral_types.h"
 #include "port/macros.h"


### PR DESCRIPTION
On Ubuntu 22.04, with gcc 11.3, this error is reported libedgetpu/makefile_build/../api/allocated_buffer.h:31:39: error: ‘size_t’ has not been declared
   31 |   AllocatedBuffer(unsigned char* ptr, size_t size_bytes,
      |                                       ^~~~~~
libedgetpu/makefile_build/../api/allocated_buffer.h:47:3: error: ‘size_t’ does not name a type
   47 |   size_t size_bytes() const { return size_bytes_; }
      |   ^~~~~~
libedgetpu/makefile_build/../api/allocated_buffer.h:19:1: note: ‘size_t’ is defined in header ‘\
<cstddef>’; did you forget to ‘#include <cstddef>’?
   18 | #include <functional>
  +++ |+#include <cstddef>

So include cstddef as recommended.

Signed-off-by: Tom Rix <trix@redhat.com>